### PR TITLE
chore: simplify CI, testing, coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,14 +20,13 @@ jobs:
           name: Install packages from lockfile
           command: npm ci
       - run:
-          name: Test suites
-          command: "npm run -s format && mkdir -p test-results && npm run -s tap -- --reporter=xunit --no-coverage > ./test-results/camelspaceTests.xml"
-      - run:
-          name: Code coverage
-          command: npm run -s tap && npx codecov
+          name: Tests and coverage
+          command: "npx mkdirp test-results && npm run -s test -- --coverage-report=lcovonly --reporter=xunit > ./test-results/camelspaceTests.xml"
       - save_cache:
           paths:
             - ~/usr/local/lib/node_modules # location depends on npm version
           key: node-v1-{{ .Branch }}-{{ checksum "package-lock.json" }}
       - store_test_results:
           path: "test-results"
+      - store_artifacts:
+          path: "coverage"

--- a/.editorconfig
+++ b/.editorconfig
@@ -4,7 +4,7 @@ root = true
 charset = utf-8
 end_of_line = lf
 indent_size = 2
-indent_style = tab
+indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
 

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,8 @@
 module.exports = {
-	env: {
-		es6: true
-	},
-	extends: ["@magento"]
+  env: {
+    es6: true,
+    node: true
+  },
+  extends: ["eslint:recommended", "plugin:package-json/recommended"],
+  plugins: ["package-json"]
 };

--- a/index.js
+++ b/index.js
@@ -5,36 +5,36 @@ const isValidEnvVarName = s => validEnvVarNamePattern.test(s);
 
 // Gets the entire object if the namespace is the empty string.
 function camelSpaceObject(obj, namespace) {
-	const camelSpaced = {};
-	for (const [key, value] of Object.entries(obj)) {
-		if (key.startsWith(namespace) && isValidEnvVarName(key)) {
-			camelSpaced[changeCase.camelCase(key.slice(namespace.length))] = value;
-		}
-	}
-	return camelSpaced;
+  const camelSpaced = {};
+  for (const [key, value] of Object.entries(obj)) {
+    if (key.startsWith(namespace) && isValidEnvVarName(key)) {
+      camelSpaced[changeCase.camelCase(key.slice(namespace.length))] = value;
+    }
+  }
+  return camelSpaced;
 }
 
 function snakeSpaceObject(obj, namespace) {
-	const snakeSpaced = {};
-	for (const [key, value] of Object.entries(obj)) {
-		const snakeKey = changeCase.constantCase(key);
-		snakeSpaced[namespace + snakeKey] = value;
-	}
-	return snakeSpaced;
+  const snakeSpaced = {};
+  for (const [key, value] of Object.entries(obj)) {
+    const snakeKey = changeCase.constantCase(key);
+    snakeSpaced[namespace + snakeKey] = value;
+  }
+  return snakeSpaced;
 }
 
 function camelspace(baseNs) {
-	const parent = baseNs ? changeCase.constantCase(baseNs) + "_" : "";
-	function transformer(scope) {
-		if (!scope) {
-			return transformer;
-		}
-		const child = changeCase.constantCase(scope);
-		return camelspace(parent + child);
-	}
-	transformer.fromEnv = obj => camelSpaceObject(obj, parent);
-	transformer.toEnv = obj => snakeSpaceObject(obj, parent);
-	return transformer;
+  const parent = baseNs ? changeCase.constantCase(baseNs) + "_" : "";
+  function transformer(scope) {
+    if (!scope) {
+      return transformer;
+    }
+    const child = changeCase.constantCase(scope);
+    return camelspace(parent + child);
+  }
+  transformer.fromEnv = obj => camelSpaceObject(obj, parent);
+  transformer.toEnv = obj => snakeSpaceObject(obj, parent);
+  return transformer;
 }
 
 module.exports = camelspace("");

--- a/index.test.js
+++ b/index.test.js
@@ -3,29 +3,29 @@ const camelspace = require("./");
 const { omit } = require("lodash");
 
 const APP_CORE_ENV = {
-	MY_APP_CORE_MODE: "test",
-	MY_APP_CORE_TOKEN: "ba6bd9a8e6da"
+  MY_APP_CORE_MODE: "test",
+  MY_APP_CORE_TOKEN: "ba6bd9a8e6da"
 };
 
 const APP_ENV = Object.assign(
-	{
-		MY_APP_CI_TOKEN: "1730eb9867d",
-		MY_APP_TELEMETRY_API_ENDPOINT: "https://example.com",
-		MY_APP_TELEMETRY_LOG_ENABLED: "1",
-		MY_APP_TELEMETRY_LOG_LEVEL: "debug"
-	},
-	APP_CORE_ENV
+  {
+    MY_APP_CI_TOKEN: "1730eb9867d",
+    MY_APP_TELEMETRY_API_ENDPOINT: "https://example.com",
+    MY_APP_TELEMETRY_LOG_ENABLED: "1",
+    MY_APP_TELEMETRY_LOG_LEVEL: "debug"
+  },
+  APP_CORE_ENV
 );
 
 // Mix the app namespace with other stuff, for testability.
 const MOCK_ENV = Object.assign(
-	{
-		THIRD_PARTY_VAR: "Who knows!",
-		THIRD_PARTY_NULLABLE_BOOLEAN: "",
-		HOST: "a.url...maybe?!",
-		port: "655E9🐘"
-	},
-	APP_ENV
+  {
+    THIRD_PARTY_VAR: "Who knows!",
+    THIRD_PARTY_NULLABLE_BOOLEAN: "",
+    HOST: "a.url...maybe?!",
+    port: "655E9🐘"
+  },
+  APP_ENV
 );
 
 // Should not come over because it is lowercase and therefore not
@@ -33,88 +33,88 @@ const MOCK_ENV = Object.assign(
 const SANITIZED_MOCK_ENV = omit(MOCK_ENV, "port");
 
 const envCamel = {
-	myAppCoreMode: "test",
-	myAppCoreToken: "ba6bd9a8e6da",
-	myAppCiToken: "1730eb9867d",
-	thirdPartyVar: "Who knows!",
-	thirdPartyNullableBoolean: "",
-	host: "a.url...maybe?!",
-	myAppTelemetryApiEndpoint: "https://example.com",
-	myAppTelemetryLogEnabled: "1",
-	myAppTelemetryLogLevel: "debug"
+  myAppCoreMode: "test",
+  myAppCoreToken: "ba6bd9a8e6da",
+  myAppCiToken: "1730eb9867d",
+  thirdPartyVar: "Who knows!",
+  thirdPartyNullableBoolean: "",
+  host: "a.url...maybe?!",
+  myAppTelemetryApiEndpoint: "https://example.com",
+  myAppTelemetryLogEnabled: "1",
+  myAppTelemetryLogLevel: "debug"
 };
 
 const appEnvCamel = {
-	coreMode: "test",
-	coreToken: "ba6bd9a8e6da",
-	ciToken: "1730eb9867d",
-	telemetryApiEndpoint: "https://example.com",
-	telemetryLogEnabled: "1",
-	telemetryLogLevel: "debug"
+  coreMode: "test",
+  coreToken: "ba6bd9a8e6da",
+  ciToken: "1730eb9867d",
+  telemetryApiEndpoint: "https://example.com",
+  telemetryLogEnabled: "1",
+  telemetryLogLevel: "debug"
 };
 
 const coreEnvCamel = {
-	mode: "test",
-	token: "ba6bd9a8e6da"
+  mode: "test",
+  token: "ba6bd9a8e6da"
 };
 
 const APP_ENV_NO_TELEMETRY_LOGGING = Object.assign({}, APP_ENV, {
-	MY_APP_TELEMETRY_LOG_ENABLED: ""
+  MY_APP_TELEMETRY_LOG_ENABLED: ""
 });
 
 tap.test(
-	"the default export .fromEnv() camelCases everything",
-	{ autoend: true },
-	t => {
-		t.strictSame(camelspace.fromEnv(MOCK_ENV), envCamel);
-	}
+  "the default export .fromEnv() camelCases everything",
+  { autoend: true },
+  t => {
+    t.strictSame(camelspace.fromEnv(MOCK_ENV), envCamel);
+  }
 );
 
 tap.test(
-	"the default export .toEnv() SNAKE_CASES everything it parsed",
-	{ autoend: true },
-	t => {
-		const env = camelspace.fromEnv(MOCK_ENV);
-		const RETURNED_ENV = camelspace.toEnv(env);
-		t.strictSame(RETURNED_ENV, SANITIZED_MOCK_ENV);
-		t.strictSame(camelspace.fromEnv(RETURNED_ENV), env);
-	}
+  "the default export .toEnv() SNAKE_CASES everything it parsed",
+  { autoend: true },
+  t => {
+    const env = camelspace.fromEnv(MOCK_ENV);
+    const RETURNED_ENV = camelspace.toEnv(env);
+    t.strictSame(RETURNED_ENV, SANITIZED_MOCK_ENV);
+    t.strictSame(camelspace.fromEnv(RETURNED_ENV), env);
+  }
 );
 
 tap.test(
-	"the default export with no arguments returns itself",
-	{ autoend: true },
-	t => {
-		const identity = camelspace();
-		t.is(identity, camelspace);
-		t.strictSame(identity.fromEnv(MOCK_ENV), envCamel);
-	}
+  "the default export with no arguments returns itself",
+  { autoend: true },
+  t => {
+    const identity = camelspace();
+    t.is(identity, camelspace);
+    t.strictSame(identity.fromEnv(MOCK_ENV), envCamel);
+  }
 );
 
 tap.test(
-	"calling a transformer as a function returns a scoped transformer",
-	{ autoend: true },
-	t => {
-		const myAppConfig = camelspace("myApp");
-		const appEnv = myAppConfig.fromEnv(MOCK_ENV);
-		t.strictSame(appEnv, appEnvCamel);
+  "calling a transformer as a function returns a scoped transformer",
+  { autoend: true },
+  t => {
+    const myAppConfig = camelspace("myApp");
+    const appEnv = myAppConfig.fromEnv(MOCK_ENV);
+    t.strictSame(appEnv, appEnvCamel);
 
-		// mutate, just to show we can
-		appEnv.telemetryLogEnabled = "";
-		const BACK_TO_THE_ENV = myAppConfig.toEnv(appEnv);
-		t.strictSame(BACK_TO_THE_ENV, APP_ENV_NO_TELEMETRY_LOGGING);
-	}
+    // mutate, just to show we can
+    appEnv.telemetryLogEnabled = "";
+    const BACK_TO_THE_ENV = myAppConfig.toEnv(appEnv);
+    t.strictSame(BACK_TO_THE_ENV, APP_ENV_NO_TELEMETRY_LOGGING);
+  }
 );
 
 tap.test(
-	"calling a scoped transformer as a function returns a deeper scoped one",
-	{ autoend: true },
-	t => {
-		const myAppConfig = camelspace("myApp");
-		const myCoreConfig = myAppConfig("core");
-		const coreEnv = myCoreConfig.fromEnv(MOCK_ENV);
-		t.strictSame(coreEnv, coreEnvCamel);
-		const CORE_ENV = myCoreConfig.toEnv(coreEnv);
-		t.strictSame(CORE_ENV, APP_CORE_ENV);
-	}
+  "calling a scoped transformer as a function returns a deeper scoped one",
+  { autoend: true },
+  t => {
+    const myAppConfig = camelspace("myApp");
+    const myCoreConfig = myAppConfig("core");
+    const coreEnv = myCoreConfig.fromEnv(MOCK_ENV);
+    t.strictSame(coreEnv, coreEnvCamel);
+    const CORE_ENV = myCoreConfig.toEnv(coreEnv);
+    t.strictSame(CORE_ENV, APP_CORE_ENV);
+  }
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -111,12 +111,6 @@
         "to-fast-properties": "^2.0.0"
       }
     },
-    "@magento/eslint-config": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@magento/eslint-config/-/eslint-config-1.4.0.tgz",
-      "integrity": "sha512-UV6MGHKrEkPmCGIuVdGZZM4JjgMpoYXAhGgun9Jqv0GiLumocgzhATRgCk0ykBb50Ztt/XiN9kxZfZ9MU0cJoA==",
-      "dev": true
-    },
     "acorn": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
@@ -198,16 +192,6 @@
         "sprintf-js": "~1.0.2"
       }
     },
-    "aria-query": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-3.0.0.tgz",
-      "integrity": "sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=",
-      "dev": true,
-      "requires": {
-        "ast-types-flow": "0.0.7",
-        "commander": "^2.11.0"
-      }
-    },
     "arr-diff": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
@@ -225,16 +209,6 @@
       "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
       "dev": true
-    },
-    "array-includes": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
-      "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.7.0"
-      }
     },
     "array-unique": {
       "version": "0.3.2",
@@ -261,12 +235,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
-      "dev": true
-    },
-    "ast-types-flow": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
-      "integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0=",
       "dev": true
     },
     "astral-regex": {
@@ -304,15 +272,6 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
       "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
       "dev": true
-    },
-    "axobject-query": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.0.2.tgz",
-      "integrity": "sha512-MCeek8ZH7hKyO1rWUbKNQBbl4l2eY0ntk7OGi+q0RlafrCnfPxC06WZA+uebCfmYp4mNU9jRBP1AhGyf8+W3ww==",
-      "dev": true,
-      "requires": {
-        "ast-types-flow": "0.0.7"
-      }
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -695,12 +654,6 @@
         "delayed-stream": "~1.0.0"
       }
     },
-    "commander": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
-      "dev": true
-    },
     "component-emitter": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
@@ -758,12 +711,6 @@
         "which": "^1.2.9"
       }
     },
-    "damerau-levenshtein": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.4.tgz",
-      "integrity": "sha1-AxkcQyy27qFou3fzpV/9zLiXhRQ=",
-      "dev": true
-    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -799,15 +746,6 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
-    },
-    "define-properties": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
-      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-      "dev": true,
-      "requires": {
-        "object-keys": "^1.0.12"
-      }
     },
     "define-property": {
       "version": "2.0.2",
@@ -928,31 +866,6 @@
         "once": "^1.4.0"
       }
     },
-    "es-abstract": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
-      "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
-      "dev": true,
-      "requires": {
-        "es-to-primitive": "^1.2.0",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "is-callable": "^1.1.4",
-        "is-regex": "^1.0.4",
-        "object-keys": "^1.0.12"
-      }
-    },
-    "es-to-primitive": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
-      "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
-      "dev": true,
-      "requires": {
-        "is-callable": "^1.1.4",
-        "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.2"
-      }
-    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -1033,22 +946,6 @@
         }
       }
     },
-    "eslint-plugin-jsx-a11y": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.2.1.tgz",
-      "integrity": "sha512-cjN2ObWrRz0TTw7vEcGQrx+YltMvZoOEx4hWU8eEERDnBIU00OTq7Vr+jA7DFKxiwLNv4tTh5Pq2GUNEa8b6+w==",
-      "dev": true,
-      "requires": {
-        "aria-query": "^3.0.0",
-        "array-includes": "^3.0.3",
-        "ast-types-flow": "^0.0.7",
-        "axobject-query": "^2.0.2",
-        "damerau-levenshtein": "^1.0.4",
-        "emoji-regex": "^7.0.2",
-        "has": "^1.0.3",
-        "jsx-ast-utils": "^2.0.1"
-      }
-    },
     "eslint-plugin-package-json": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/eslint-plugin-package-json/-/eslint-plugin-package-json-0.1.3.tgz",
@@ -1058,32 +955,6 @@
         "disparity": "^2.0.0",
         "package-json-validator": "^0.6.3",
         "requireindex": "^1.2.0"
-      }
-    },
-    "eslint-plugin-react": {
-      "version": "7.12.4",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.12.4.tgz",
-      "integrity": "sha512-1puHJkXJY+oS1t467MjbqjvX53uQ05HXwjqDgdbGBqf5j9eeydI54G3KwiJmWciQ0HTBacIKw2jgwSBSH3yfgQ==",
-      "dev": true,
-      "requires": {
-        "array-includes": "^3.0.3",
-        "doctrine": "^2.1.0",
-        "has": "^1.0.3",
-        "jsx-ast-utils": "^2.0.1",
-        "object.fromentries": "^2.0.0",
-        "prop-types": "^15.6.2",
-        "resolve": "^1.9.0"
-      },
-      "dependencies": {
-        "doctrine": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2"
-          }
-        }
       }
     },
     "eslint-scope": {
@@ -2043,12 +1914,6 @@
         }
       }
     },
-    "function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
-    },
     "function-loop": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/function-loop/-/function-loop-1.0.2.tgz",
@@ -2160,25 +2025,10 @@
         "har-schema": "^2.0.0"
       }
     },
-    "has": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
-      "requires": {
-        "function-bind": "^1.1.1"
-      }
-    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
-    },
-    "has-symbols": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
       "dev": true
     },
     "has-value": {
@@ -2359,12 +2209,6 @@
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true
     },
-    "is-callable": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
-      "dev": true
-    },
     "is-data-descriptor": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
@@ -2384,12 +2228,6 @@
           }
         }
       }
-    },
-    "is-date-object": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
-      "dev": true
     },
     "is-descriptor": {
       "version": "0.1.6",
@@ -2480,29 +2318,11 @@
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
     },
-    "is-regex": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
-      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-      "dev": true,
-      "requires": {
-        "has": "^1.0.1"
-      }
-    },
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
-    },
-    "is-symbol": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
-      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
-      "dev": true,
-      "requires": {
-        "has-symbols": "^1.0.0"
-      }
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -2633,15 +2453,6 @@
         "verror": "1.10.0"
       }
     },
-    "jsx-ast-utils": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz",
-      "integrity": "sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=",
-      "dev": true,
-      "requires": {
-        "array-includes": "^3.0.3"
-      }
-    },
     "kind-of": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
@@ -2694,15 +2505,6 @@
       "resolved": "https://registry.npmjs.org/log-driver/-/log-driver-1.2.7.tgz",
       "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
       "dev": true
-    },
-    "loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
-      "requires": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      }
     },
     "lower-case": {
       "version": "1.1.4",
@@ -4008,12 +3810,6 @@
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
       "dev": true
     },
-    "object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
-    },
     "object-copy": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
@@ -4045,12 +3841,6 @@
         }
       }
     },
-    "object-keys": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true
-    },
     "object-visit": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
@@ -4058,18 +3848,6 @@
       "dev": true,
       "requires": {
         "isobject": "^3.0.0"
-      }
-    },
-    "object.fromentries": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.0.tgz",
-      "integrity": "sha512-9iLiI6H083uiqUuvzyY6qrlmc/Gz8hLQFOcb/Ri/0xXFkSNS3ctV+CbE6yM2+AnkYfOB3dGjdzC0wrMLIhQICA==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.11.0",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.1"
       }
     },
     "object.pick": {
@@ -4302,12 +4080,6 @@
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
       "dev": true
     },
-    "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-      "dev": true
-    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -4344,17 +4116,6 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
-    "prop-types": {
-      "version": "15.7.2",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-      "dev": true,
-      "requires": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.8.1"
-      }
-    },
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
@@ -4387,12 +4148,6 @@
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-      "dev": true
-    },
-    "react-is": {
-      "version": "16.8.6",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
-      "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA==",
       "dev": true
     },
     "readable-stream": {
@@ -4500,15 +4255,6 @@
       "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
       "integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==",
       "dev": true
-    },
-    "resolve": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
-      "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
-      "dev": true,
-      "requires": {
-        "path-parse": "^1.0.6"
-      }
     },
     "resolve-from": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -7,11 +7,12 @@
     "index.js"
   ],
   "scripts": {
-    "format": "prettier --write \"./*.js\" && eslint --fix ./*.{js,json}",
+    "format": "prettier --loglevel warn --write \"./*.js\" && eslint --quiet --fix ./*.{js,json}",
     "prepublishOnly": "npm run -s test",
-    "tap": "tap --cov *.test.js",
-    "test": "npm run -s format && npm run -s tap",
-    "test:dev": "chokidar --silent --polling --initial \"./*.js\" -c \"npm run -s tap\""
+    "tap": "tap *.test.js",
+    "test": "npm run -s format && npm run -s tap -- --cov",
+    "test:ci": "mkdirp test-results && npm run -s test -- --coverage-report=lcovonly --reporter=xunit > ./test-results/camelspaceTests.xml",
+    "test:dev": "chokidar --silent --polling --initial \"./*.js\" -c \"npm run -s test\""
   },
   "repository": {
     "type": "git",
@@ -34,13 +35,9 @@
     "change-case": "^3.1.0"
   },
   "devDependencies": {
-    "@magento/eslint-config": "^1.4.0",
     "chokidar-cli": "^1.2.2",
     "eslint": "^5.16.0",
-    "eslint-plugin-jsx-a11y": "^6.2.1",
     "eslint-plugin-package-json": "^0.1.3",
-    "eslint-plugin-react": "^7.12.4",
-    "lodash": "^4.17.11",
     "prettier": "1.16.4",
     "tap": "^12.6.1"
   }


### PR DESCRIPTION
Emit test results xunit and coverage in one step. Centralize this in package.json instead of CI provider specific stuff.