### PR TITLE
Zetlen/fluent api

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,6 +32,14 @@ function camelspace(baseNs) {
     const child = changeCase.constantCase(scope);
     return camelspace(parent + child);
   }
+  transformer.for = (
+    scope,
+    sections,
+    /* istanbul ignore next: tests argue this */ envObj = process.env
+  ) => {
+    const space = transformer(scope);
+    return sections.map(section => space(section).fromEnv(envObj));
+  };
   transformer.fromEnv = obj => camelSpaceObject(obj, parent);
   transformer.toEnv = obj => snakeSpaceObject(obj, parent);
   return transformer;

--- a/index.test.js
+++ b/index.test.js
@@ -62,6 +62,26 @@ const APP_ENV_NO_TELEMETRY_LOGGING = Object.assign({}, APP_ENV, {
   MY_APP_TELEMETRY_LOG_ENABLED: ""
 });
 
+tap.test("the fluent .for api works", { autoend: true }, t => {
+  t.strictSame(camelspace.for("myApp", ["core"], MOCK_ENV), [
+    {
+      mode: appEnvCamel.coreMode,
+      token: appEnvCamel.coreToken
+    }
+  ]);
+});
+
+tap.test("the fluent .for api works in factories", { autoend: true }, t => {
+  const myAppConfig = camelspace("myApp");
+  t.strictSame(myAppConfig.for("telemetry", ["log", "api"], MOCK_ENV), [
+    {
+      enabled: appEnvCamel.telemetryLogEnabled,
+      level: appEnvCamel.telemetryLogLevel
+    },
+    { endpoint: appEnvCamel.telemetryApiEndpoint }
+  ]);
+});
+
 tap.test(
   "the default export .fromEnv() camelCases everything",
   { autoend: true },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "camelspace",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "camelspace",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Transform flat ENVIRONMENT_VARIABLES into deep { environment: { variables } } objects and vice versa.",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
Add a fluent API for a less verbose common case, where several configuration sections are necessary and `process.env` is the env object.